### PR TITLE
[Feat] 지도 연동 및 필터링 항목 틀 작성

### DIFF
--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -85,7 +85,7 @@ function AppInner() {
             headerShown: false,
           }}>
           <Tab.Screen
-            name="FavoriteModal"
+            name="즐겨찾기"
             component={FavoriteModal}
             listeners={() => ({
               tabPress: e => {
@@ -94,7 +94,7 @@ function AppInner() {
             })}
           />
           <Tab.Screen
-            name="AroundModal"
+            name="주변"
             component={AroundModal}
             listeners={() => ({
               tabPress: e => {

--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -13,8 +13,6 @@ import {Modal, Pressable, Text, View} from 'react-native';
 export type LoggedInParamList = {
   StoreMap: undefined;
   Setting: undefined;
-  AroundModal: undefined;
-  FavoriteModal: undefined;
 };
 
 export type RootStackParamList = {
@@ -37,19 +35,20 @@ const MyPage = () => {
 
 function AppInner() {
   const [isLoggedIn, setLoggedIn] = useState(true);
-  const [modalVisible, setModalVisible] = useState(false);
-  const FModal = () => {
+  const [favoriteVisible, setFavoriteVisible] = useState(false);
+  const [aroundVisible, setAroundVisible] = useState(false);
+  const FavoriteModal = () => {
     return (
       <View>
         <StoreMap />
         <Modal
           animationType="slide"
-          visible={modalVisible}
+          visible={favoriteVisible}
           statusBarTranslucent>
           <Text style={{textAlign: 'center'}}>Create Posts !! This is Modal</Text>
           <Pressable
             onPress={() => {
-              setModalVisible(!modalVisible);
+              setFavoriteVisible(!favoriteVisible);
             }}>
             <Text>hi</Text>
           </Pressable>
@@ -57,22 +56,22 @@ function AppInner() {
       </View>
     );
   };
-  const AModal = () => {
+  const AroundModal = () => {
     return (
       <View>
         <StoreMap />
         <Modal
           animationType="slide"
-          visible={modalVisible}
+          visible={aroundVisible}
           statusBarTranslucent>
           <Text style={{textAlign: 'center'}}>
             Create Posts !! This is Modal
           </Text>
           <Pressable
             onPress={() => {
-              setModalVisible(!modalVisible);
+              setAroundVisible(!aroundVisible);
             }}>
-            <Text>hi</Text>
+            <Text>around</Text>
           </Pressable>
         </Modal>
       </View>
@@ -86,20 +85,20 @@ function AppInner() {
             headerShown: false,
           }}>
           <Tab.Screen
-            name="FModal"
-            component={FModal}
+            name="FavoriteModal"
+            component={FavoriteModal}
             listeners={() => ({
               tabPress: e => {
-                setModalVisible(!modalVisible);
+                setFavoriteVisible(!favoriteVisible);
               },
             })}
           />
           <Tab.Screen
-            name="AModal"
-            component={AModal}
+            name="AroundModal"
+            component={AroundModal}
             listeners={() => ({
               tabPress: e => {
-                setModalVisible(!modalVisible);
+                setAroundVisible(!aroundVisible);
               },
             })}
           />

--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -8,7 +8,7 @@ import SignIn from './src/pages/SignIn';
 import SignUp from './src/pages/SignUp';
 import StoreMap from './src/pages/StoreMap';
 import Setting from './src/pages/Setting';
-import {FavoriteModal, AroundModal} from './src/components/Modal';
+import {Modal, Pressable, Text, View} from 'react-native';
 
 export type LoggedInParamList = {
   StoreMap: undefined;
@@ -26,34 +26,6 @@ const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const mainStack = createNativeStackNavigator<LoggedInParamList>();
 
-//즐겨찾기
-const Favorite = () => {
-  return (
-    <mainStack.Navigator>
-      <mainStack.Screen name="StoreMap" component={StoreMap} />
-      <mainStack.Screen
-        name="FavoriteModal"
-        component={FavoriteModal}
-        options={{presentation: 'transparentModal'}}
-      />
-    </mainStack.Navigator>
-  );
-};
-
-//주변
-const Around = () => {
-  return (
-    <mainStack.Navigator>
-      <mainStack.Screen name="StoreMap" component={StoreMap} />
-      <mainStack.Screen
-        name="AroundModal"
-        component={AroundModal}
-        options={{presentation: 'transparentModal'}}
-      />
-    </mainStack.Navigator>
-  );
-};
-
 //마이페이지
 const MyPage = () => {
   return (
@@ -65,6 +37,47 @@ const MyPage = () => {
 
 function AppInner() {
   const [isLoggedIn, setLoggedIn] = useState(true);
+  const [modalVisible, setModalVisible] = useState(false);
+  const FModal = () => {
+    return (
+      <View>
+        <StoreMap />
+        <Modal
+          animationType="slide"
+          visible={modalVisible}
+          statusBarTranslucent>
+          <Text style={{textAlign: 'center'}}>Create Posts !! This is Modal</Text>
+          <Pressable
+            onPress={() => {
+              setModalVisible(!modalVisible);
+            }}>
+            <Text>hi</Text>
+          </Pressable>
+        </Modal>
+      </View>
+    );
+  };
+  const AModal = () => {
+    return (
+      <View>
+        <StoreMap />
+        <Modal
+          animationType="slide"
+          visible={modalVisible}
+          statusBarTranslucent>
+          <Text style={{textAlign: 'center'}}>
+            Create Posts !! This is Modal
+          </Text>
+          <Pressable
+            onPress={() => {
+              setModalVisible(!modalVisible);
+            }}>
+            <Text>hi</Text>
+          </Pressable>
+        </Modal>
+      </View>
+    );
+  };
   return (
     <NavigationContainer>
       {isLoggedIn ? (
@@ -73,24 +86,20 @@ function AppInner() {
             headerShown: false,
           }}>
           <Tab.Screen
-            name="Favorite"
-            component={Favorite}
-            options={{title: '즐겨찾기'}}
-            listeners={({navigation}) => ({
+            name="FModal"
+            component={FModal}
+            listeners={() => ({
               tabPress: e => {
-                e.preventDefault();
-                navigation.navigate('Favorite', {screen: 'FavoriteModal'});
+                setModalVisible(!modalVisible);
               },
             })}
           />
           <Tab.Screen
-            name="Around"
-            component={Around}
-            options={{title: '주변'}}
-            listeners={({navigation}) => ({
+            name="AModal"
+            component={AModal}
+            listeners={() => ({
               tabPress: e => {
-                e.preventDefault();
-                navigation.navigate('Around', {screen: 'AroundModal'});
+                setModalVisible(!modalVisible);
               },
             })}
           />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+      <!--네이버 맵-->
+      <meta-data
+            android:name="com.naver.maps.map.CLIENT_ID"
+            android:value="d7zngjmrq6" />
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/ios/wheretogo/Info.plist
+++ b/ios/wheretogo/Info.plist
@@ -32,6 +32,9 @@
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
+				<!--네이버 맵-->
+				<key>NMFClientId</key>
+    			<string>d7zngjmrq6</string>
 			</dict>
 		</dict>
 	</dict>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "patch-package": "^7.0.0",
         "react": "18.2.0",
         "react-native": "0.72.1",
+        "react-native-bouncy-checkbox": "^3.0.7",
         "react-native-code-push": "^8.0.2",
         "react-native-config": "^1.5.1",
         "react-native-encrypted-storage": "^4.0.3",
@@ -12761,6 +12762,15 @@
       },
       "peerDependencies": {
         "react": "18.2.0"
+      }
+    },
+    "node_modules/react-native-bouncy-checkbox": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-bouncy-checkbox/-/react-native-bouncy-checkbox-3.0.7.tgz",
+      "integrity": "sha512-776TgMGt9wTpOQA1TcvFjL5VUn6o945wFYf3Ztqva62/vT2o3JAezLiP7hYh2Svd+PewfWBYSPMs4jeaSoS8Sg==",
+      "peerDependencies": {
+        "react": ">= 16.x.x",
+        "react-native": ">= 0.55.x"
       }
     },
     "node_modules/react-native-code-push": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "patch-package": "^7.0.0",
     "react": "18.2.0",
     "react-native": "0.72.1",
+    "react-native-bouncy-checkbox": "^3.0.7",
     "react-native-code-push": "^8.0.2",
     "react-native-config": "^1.5.1",
     "react-native-encrypted-storage": "^4.0.3",

--- a/src/components/Filter1.tsx
+++ b/src/components/Filter1.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import {Pressable, Text, View, StyleSheet, Button} from 'react-native';
+import {useState} from 'react';
+
+const Filter1 = props => {
+  const [number, setNumber] = useState(0);
+  const increaseNumber = (num: number) => {
+    let a = num;
+    a++;
+    setNumber(a);
+  };
+  const decreaseNumber = (num: number) => {
+    let a = num;
+    a--;
+    setNumber(a);
+    if (a < 0) {
+      setNumber(0);
+    }
+  };
+
+  return (
+    <View style={styles.filterModalBox}>
+      <View style={styles.filterModal}>
+        <Text>인원 수</Text>
+        <View style={{flexDirection: 'row'}}>
+          <Button title="-" onPress={() => decreaseNumber(number)} />
+          <Text>{number}</Text>
+          <Button title="+" onPress={() => increaseNumber(number)} />
+        </View>
+        <View style={{flexDirection: 'row'}}>
+          <Pressable>
+            <Text
+              onPress={() => {
+                props.setCheckVisible(false), setNumber(0);
+              }}>
+              취소
+            </Text>
+          </Pressable>
+          <Pressable>
+            <Text
+              onPress={() => {
+                props.setCheckVisible(false), setNumber(0);
+              }}>
+              확인
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  filterModalBox: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  filterModal: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+});
+
+export default Filter1;

--- a/src/components/Filter2.tsx
+++ b/src/components/Filter2.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import {Pressable, Text, View, StyleSheet, Image} from 'react-native';
+import {useState} from 'react';
+import BouncyCheckbox from "react-native-bouncy-checkbox";
+
+const Filter1 = props => {
+  return (
+    <View style={styles.filterModalBox}>
+      <View style={styles.filterModal}>
+        <Text>선호하는 주점 종류</Text>
+        <View
+          style={{
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'space-between',
+            marginTop: 20,
+          }}>
+          <BouncyCheckbox
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="생맥주집"
+            iconStyle={{borderColor: '#4E6D5E', borderRadius: 8}}
+            innerIconStyle={{borderWidth: 2, borderRadius: 8}}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="이자카야"
+            iconStyle={{borderColor: '#4E6D5E', borderRadius: 8}}
+            innerIconStyle={{borderWidth: 2, borderRadius: 8}}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="포장마차"
+            iconStyle={{borderColor: '#4E6D5E', borderRadius: 8}}
+            innerIconStyle={{borderWidth: 2, borderRadius: 8}}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="대폿집"
+            iconStyle={{borderColor: '#4E6D5E', borderRadius: 8}}
+            innerIconStyle={{borderWidth: 2, borderRadius: 8}}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="개인 룸"
+            iconStyle={{borderColor: '#4E6D5E', borderRadius: 8}}
+            innerIconStyle={{borderWidth: 2, borderRadius: 8}}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="바 형태"
+            iconStyle={{borderColor: '#4E6D5E', borderRadius: 8}}
+            innerIconStyle={{borderWidth: 2, borderRadius: 8}}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+        </View>
+        <View style={{flexDirection: 'row', marginTop: 20}}>
+          <Pressable>
+            <Text onPress={() => props.setCategoryVisible(false)}>취소</Text>
+          </Pressable>
+          <Pressable>
+            <Text onPress={() => props.setCategoryVisible(false)}>확인</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  filterModalBox: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  filterModal: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+});
+
+export default Filter1;

--- a/src/components/Filter3.tsx
+++ b/src/components/Filter3.tsx
@@ -3,11 +3,11 @@ import {Pressable, Text, View, StyleSheet, Image} from 'react-native';
 import {useState} from 'react';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
 
-const Filter2 = props => {
+const Filter3 = props => {
   return (
     <View style={styles.filterModalBox}>
       <View style={styles.filterModal}>
-        <Text>주점 종류를 선택해주세요</Text>
+        <Text>주종을 골라주세요</Text>
         <View
           style={{
             flexDirection: 'row',
@@ -19,7 +19,7 @@ const Filter2 = props => {
             size={24}
             fillColor="#4E6D5E"
             unfillColor="#FFFFFF"
-            text="생맥주집"
+            text="칵테일"
             iconStyle={styles.iconStyle}
             innerIconStyle={styles.innerIconStyle}
             textStyle={{textDecorationLine: 'none'}}
@@ -29,7 +29,7 @@ const Filter2 = props => {
             size={24}
             fillColor="#4E6D5E"
             unfillColor="#FFFFFF"
-            text="이자카야"
+            text="와인바"
             iconStyle={styles.iconStyle}
             innerIconStyle={styles.innerIconStyle}
             textStyle={{textDecorationLine: 'none'}}
@@ -39,18 +39,7 @@ const Filter2 = props => {
             size={24}
             fillColor="#4E6D5E"
             unfillColor="#FFFFFF"
-            text="포장마차"
-            iconStyle={styles.iconStyle}
-            innerIconStyle={styles.innerIconStyle}
-            textStyle={{textDecorationLine: 'none'}}
-            textContainerStyle={{marginLeft: 7}}
-          />
-          <BouncyCheckbox
-            style={{marginTop: 10}}
-            size={24}
-            fillColor="#4E6D5E"
-            unfillColor="#FFFFFF"
-            text="대폿집"
+            text="소주, 맥주"
             iconStyle={styles.iconStyle}
             innerIconStyle={styles.innerIconStyle}
             textStyle={{textDecorationLine: 'none'}}
@@ -61,7 +50,7 @@ const Filter2 = props => {
             size={24}
             fillColor="#4E6D5E"
             unfillColor="#FFFFFF"
-            text="개인 룸"
+            text="생맥주"
             iconStyle={styles.iconStyle}
             innerIconStyle={styles.innerIconStyle}
             textStyle={{textDecorationLine: 'none'}}
@@ -72,7 +61,51 @@ const Filter2 = props => {
             size={24}
             fillColor="#4E6D5E"
             unfillColor="#FFFFFF"
-            text="바 형태"
+            text="보드카"
+            iconStyle={styles.iconStyle}
+            innerIconStyle={styles.innerIconStyle}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="세계 맥주"
+            iconStyle={styles.iconStyle}
+            innerIconStyle={styles.innerIconStyle}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="막걸리"
+            iconStyle={styles.iconStyle}
+            innerIconStyle={styles.innerIconStyle}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="과일소주"
+            iconStyle={styles.iconStyle}
+            innerIconStyle={styles.innerIconStyle}
+            textStyle={{textDecorationLine: 'none'}}
+            textContainerStyle={{marginLeft: 7}}
+          />
+          <BouncyCheckbox
+            style={{marginTop: 10}}
+            size={24}
+            fillColor="#4E6D5E"
+            unfillColor="#FFFFFF"
+            text="시그니처"
             iconStyle={styles.iconStyle}
             innerIconStyle={styles.innerIconStyle}
             textStyle={{textDecorationLine: 'none'}}
@@ -81,10 +114,10 @@ const Filter2 = props => {
         </View>
         <View style={{flexDirection: 'row', marginTop: 20}}>
           <Pressable>
-            <Text onPress={() => props.setCategoryVisible(false)}>취소</Text>
+            <Text onPress={() => props.setLiquorVisible(false)}>취소</Text>
           </Pressable>
           <Pressable>
-            <Text onPress={() => props.setCategoryVisible(false)}>확인</Text>
+            <Text onPress={() => props.setLiquorVisible(false)}>확인</Text>
           </Pressable>
         </View>
       </View>
@@ -118,4 +151,4 @@ const styles = StyleSheet.create({
   innerIconStyle: {borderWidth: 2, borderRadius: 8},
 });
 
-export default Filter2;
+export default Filter3;

--- a/src/components/Filter4.tsx
+++ b/src/components/Filter4.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import {
+  Pressable,
+  Text,
+  View,
+  StyleSheet,
+  FlatList,
+  Dimensions,
+} from 'react-native';
+import {useState} from 'react';
+
+const Filter4 = props => {
+  const arr = [];
+  for (let i = 0; i < 10; i++) {
+    arr.push('가상의 선호 지역 명');
+  }
+  return (
+    <View style={styles.filterModalBox}>
+      <View style={styles.filterModal}>
+        <Pressable style={{alignSelf: 'flex-start'}}>
+          <Text onPress={() => props.setFavorLocation(false)}>X</Text>
+        </Pressable>
+        <Text>등록된 선호 지역입니다 :)</Text>
+        <View
+          style={{
+            flexDirection: 'row',
+            marginTop: 20,
+          }}>
+          <FlatList
+            data={arr}
+            keyExtractor={item => item.toString()}
+            renderItem={({item}) => <Text>{item}</Text>}
+          />
+        </View>
+        <View style={{flexDirection: 'row', marginTop: 20}}></View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  filterModalBox: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  filterModal: {
+    margin: 20,
+    backgroundColor: 'white',
+    height: Dimensions.get('window').height,
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+});
+
+export default Filter4;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import {Pressable, Text, View} from 'react-native';
+import {Pressable, Text, View, StyleSheet, Modal, Alert} from 'react-native';
 import {StackNavigationProp} from '@react-navigation/stack';
+import {useState} from 'react';
 
 type Props = {
   navigation: StackNavigationProp;
@@ -11,7 +12,10 @@ const FavoriteModal = ({navigation}: Props) => {
   return (
     <View style={{flex: 1}}>
       <Pressable
-        style={[{backgroundColor: 'rgba(0, 0, 0, 0.3)'}]}
+        style={[
+          StyleSheet.absoluteFill,
+          {backgroundColor: 'rgba(0, 0, 0, 0.3)'},
+        ]}
         onPress={navigation.goBack}
       />
       <View
@@ -33,7 +37,10 @@ const AroundModal = ({navigation}: Props) => {
   return (
     <View style={{flex: 1}}>
       <Pressable
-        style={[{backgroundColor: 'rgba(0, 0, 0, 0.3)'}]}
+        style={[
+          StyleSheet.absoluteFill,
+          {backgroundColor: 'rgba(0, 0, 0, 0.3)'},
+        ]}
         onPress={navigation.goBack}
       />
       <View

--- a/src/pages/StoreMap.tsx
+++ b/src/pages/StoreMap.tsx
@@ -1,8 +1,22 @@
-import React from 'react';
-import {Alert, Button, Dimensions, View, TextInput} from 'react-native';
+import React, {useState} from 'react';
+import {
+  Alert,
+  Button,
+  Dimensions,
+  View,
+  TextInput,
+  Text,
+  StyleSheet,
+  Modal,
+} from 'react-native';
 import NaverMapView, {Marker, Path} from 'react-native-nmap';
+import Filter1 from '../components/Filter1';
 
 function StoreMap() {
+  const [latitude, setLatitude] = useState(37.56667);
+  const [longitude, setLongitude] = useState(126.97806);
+  const [checkvisible, setCheckVisible] = useState(false);
+
   return (
     <View>
       <View
@@ -11,58 +25,111 @@ function StoreMap() {
           width: Dimensions.get('window').width,
           height: Dimensions.get('window').height,
         }}>
-        <View>
+        <View style={{flexDirection: 'row'}}>
           <TextInput
+            style={{backgroundColor: 'pink', flex: 1}}
             placeholder="검색할 내용을 입력해 주세요. 예: 강남 시티뷰가 좋은 집"
             //onChangeText={(text): void => setSearchWord(text)}
           />
           <Button
             title="검색하기"
-            // onPress={(): void => {
-            //   axiosInstance
-            //     .post('houses/search', {
-            //       searchWord,
-            //     })
-            //     .then(res => {
-            //       const searchHouse = res.data.map((house: any) => {
-            //         return {
-            //           id: house.id,
-            //           title: house.title,
-            //           coordinate: {
-            //             latitude: Number(house.location[0]),
-            //             longitude: Number(house.location[1]),
-            //           },
-            //         };
-            //       });
-            //       setMarkers(searchHouse);
-            //     });
-            // }}
+            onPress={(): void => {
+              setLatitude(37.56667);
+              setLongitude(126.97);
+              // axiosInstance
+              //   .post('houses/search', {
+              //     searchWord,
+              //   })
+              //   .then(res => {
+              //     const searchHouse = res.data.map((house: any) => {
+              //       return {
+              //         id: house.id,
+              //         title: house.title,
+              //         coordinate: {
+              //           latitude: Number(house.location[0]),
+              //           longitude: Number(house.location[1]),
+              //         },
+              //       };
+              //     });
+              //     setMarkers(searchHouse);
+              //   });
+            }}
           />
+        </View>
+        <View style={styles.filterBox}>
+          <Button title="인원수" onPress={() => setCheckVisible(true)} />
+          <Modal visible={checkvisible} transparent statusBarTranslucent>
+            <Filter1 setCheckVisible={setCheckVisible} />
+          </Modal>
+          <Button title="주점 종류" onPress={() => Alert.alert('주점 종류')} />
+          <Button title="주종" onPress={() => Alert.alert('주종')} />
+          <Button title="선호 지역" onPress={() => Alert.alert('선호 지역')} />
+        </View>
+        <View style={styles.reservation}>
+          <Text>예약 현황</Text>
+          <Text> {`>`} </Text>
         </View>
         <NaverMapView
           style={{width: '100%', height: '100%'}}
           zoomControl={false}
           center={{
             zoom: 16,
-            tilt: 0,
-            latitude: 37.56667,
-            longitude: 126.97806,
+            tilt: 10,
+            latitude: latitude,
+            longitude: longitude,
           }}
         />
-        <View
-          style={{
-            position: 'absolute',
-            top: '80%',
-            alignSelf: 'auto',
-          }}>
+        <View style={styles.currentStatus}>
           <Button
             title="현재 위치"
-            onPress={() => Alert.alert('현재위치 표시하는 버튼')}
+            onPress={() => {
+              setLatitude(37.56667);
+              setLongitude(126.97806);
+            }}
           />
         </View>
       </View>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  filterBox: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    backgroundColor: 'white',
+  },
+  reservation: {
+    flexDirection: 'row',
+    backgroundColor: 'green',
+    justifyContent: 'flex-end',
+  },
+  currentStatus: {
+    position: 'absolute',
+    top: '90%',
+    alignSelf: 'auto',
+  },
+  filterModalBox: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  filterModal: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+});
 
 export default StoreMap;

--- a/src/pages/StoreMap.tsx
+++ b/src/pages/StoreMap.tsx
@@ -12,13 +12,14 @@ import {
 import NaverMapView, {Marker, Path} from 'react-native-nmap';
 import Filter1 from '../components/Filter1';
 import Filter2 from '../components/Filter2';
+import Filter3 from '../components/Filter3';
 
 function StoreMap() {
   const [latitude, setLatitude] = useState(37.56667);
   const [longitude, setLongitude] = useState(126.97806);
   const [checkvisible, setCheckVisible] = useState(false);
   const [categoryVisible, setCategoryVisible] = useState(false);
-
+  const [liquorVisible, setLiquorVisible] = useState(false);
 
   return (
     <View>
@@ -68,7 +69,10 @@ function StoreMap() {
           <Modal visible={categoryVisible} transparent statusBarTranslucent>
             <Filter2 setCategoryVisible={setCategoryVisible} />
           </Modal>
-          <Button title="주종" onPress={() => Alert.alert('주종')} />
+          <Button title="주종" onPress={() => setLiquorVisible(true)} />
+          <Modal visible={liquorVisible} transparent statusBarTranslucent>
+            <Filter3 setLiquorVisible={setLiquorVisible} />
+          </Modal>
           <Button title="선호 지역" onPress={() => Alert.alert('선호 지역')} />
         </View>
         <View style={styles.reservation}>

--- a/src/pages/StoreMap.tsx
+++ b/src/pages/StoreMap.tsx
@@ -1,15 +1,8 @@
 import React from 'react';
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {LoggedInParamList} from '../../AppInner';
 import {Alert, Button, Dimensions, View, TextInput} from 'react-native';
 import NaverMapView, {Marker, Path} from 'react-native-nmap';
 
-type StoreMapScreenProps = NativeStackScreenProps<
-  LoggedInParamList,
-  'StoreMap'
->;
-
-function StoreMap({}: StoreMapScreenProps) {
+function StoreMap() {
   return (
     <View>
       <View

--- a/src/pages/StoreMap.tsx
+++ b/src/pages/StoreMap.tsx
@@ -11,11 +11,14 @@ import {
 } from 'react-native';
 import NaverMapView, {Marker, Path} from 'react-native-nmap';
 import Filter1 from '../components/Filter1';
+import Filter2 from '../components/Filter2';
 
 function StoreMap() {
   const [latitude, setLatitude] = useState(37.56667);
   const [longitude, setLongitude] = useState(126.97806);
   const [checkvisible, setCheckVisible] = useState(false);
+  const [categoryVisible, setCategoryVisible] = useState(false);
+
 
   return (
     <View>
@@ -61,7 +64,10 @@ function StoreMap() {
           <Modal visible={checkvisible} transparent statusBarTranslucent>
             <Filter1 setCheckVisible={setCheckVisible} />
           </Modal>
-          <Button title="주점 종류" onPress={() => Alert.alert('주점 종류')} />
+          <Button title="주점 종류" onPress={() => setCategoryVisible(true)} />
+          <Modal visible={categoryVisible} transparent statusBarTranslucent>
+            <Filter2 setCategoryVisible={setCategoryVisible} />
+          </Modal>
           <Button title="주종" onPress={() => Alert.alert('주종')} />
           <Button title="선호 지역" onPress={() => Alert.alert('선호 지역')} />
         </View>

--- a/src/pages/StoreMap.tsx
+++ b/src/pages/StoreMap.tsx
@@ -13,6 +13,7 @@ import NaverMapView, {Marker, Path} from 'react-native-nmap';
 import Filter1 from '../components/Filter1';
 import Filter2 from '../components/Filter2';
 import Filter3 from '../components/Filter3';
+import Filter4 from '../components/Filter4';
 
 function StoreMap() {
   const [latitude, setLatitude] = useState(37.56667);
@@ -20,6 +21,7 @@ function StoreMap() {
   const [checkvisible, setCheckVisible] = useState(false);
   const [categoryVisible, setCategoryVisible] = useState(false);
   const [liquorVisible, setLiquorVisible] = useState(false);
+  const [favorLocation, setFavorLocation] = useState(false);
 
   return (
     <View>
@@ -31,7 +33,7 @@ function StoreMap() {
         }}>
         <View style={{flexDirection: 'row'}}>
           <TextInput
-            style={{backgroundColor: 'pink', flex: 1}}
+            style={{backgroundColor: '#F2F2F2', flex: 1}}
             placeholder="검색할 내용을 입력해 주세요. 예: 강남 시티뷰가 좋은 집"
             //onChangeText={(text): void => setSearchWord(text)}
           />
@@ -73,11 +75,14 @@ function StoreMap() {
           <Modal visible={liquorVisible} transparent statusBarTranslucent>
             <Filter3 setLiquorVisible={setLiquorVisible} />
           </Modal>
-          <Button title="선호 지역" onPress={() => Alert.alert('선호 지역')} />
+          <Button title="선호 지역" onPress={() => setFavorLocation(true)} />
+          <Modal visible={favorLocation} transparent statusBarTranslucent>
+            <Filter4 setFavorLocation={setFavorLocation} />
+          </Modal>
         </View>
         <View style={styles.reservation}>
-          <Text>예약 현황</Text>
-          <Text> {`>`} </Text>
+          <Text style={{color: 'white'}}>예약 현황</Text>
+          <Text style={{color: 'white'}}> {`>`} </Text>
         </View>
         <NaverMapView
           style={{width: '100%', height: '100%'}}
@@ -111,8 +116,9 @@ const styles = StyleSheet.create({
   },
   reservation: {
     flexDirection: 'row',
-    backgroundColor: 'green',
+    backgroundColor: '#4E6D5E',
     justifyContent: 'flex-end',
+    padding: 5,
   },
   currentStatus: {
     position: 'absolute',

--- a/src/pages/StoreMap.tsx
+++ b/src/pages/StoreMap.tsx
@@ -1,16 +1,73 @@
 import React from 'react';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {LoggedInParamList} from '../../App';
-import {Text, View} from 'react-native';
+import {LoggedInParamList} from '../../AppInner';
+import {Alert, Button, Dimensions, View, TextInput} from 'react-native';
+import NaverMapView, {Marker, Path} from 'react-native-nmap';
 
 type StoreMapScreenProps = NativeStackScreenProps<
   LoggedInParamList,
   'StoreMap'
 >;
+
 function StoreMap({}: StoreMapScreenProps) {
   return (
     <View>
-      <Text>지도</Text>
+      <View
+        //화면 꽉 차게
+        style={{
+          width: Dimensions.get('window').width,
+          height: Dimensions.get('window').height,
+        }}>
+        <View>
+          <TextInput
+            placeholder="검색할 내용을 입력해 주세요. 예: 강남 시티뷰가 좋은 집"
+            //onChangeText={(text): void => setSearchWord(text)}
+          />
+          <Button
+            title="검색하기"
+            // onPress={(): void => {
+            //   axiosInstance
+            //     .post('houses/search', {
+            //       searchWord,
+            //     })
+            //     .then(res => {
+            //       const searchHouse = res.data.map((house: any) => {
+            //         return {
+            //           id: house.id,
+            //           title: house.title,
+            //           coordinate: {
+            //             latitude: Number(house.location[0]),
+            //             longitude: Number(house.location[1]),
+            //           },
+            //         };
+            //       });
+            //       setMarkers(searchHouse);
+            //     });
+            // }}
+          />
+        </View>
+        <NaverMapView
+          style={{width: '100%', height: '100%'}}
+          zoomControl={false}
+          center={{
+            zoom: 16,
+            tilt: 0,
+            latitude: 37.56667,
+            longitude: 126.97806,
+          }}
+        />
+        <View
+          style={{
+            position: 'absolute',
+            top: '80%',
+            alignSelf: 'auto',
+          }}>
+          <Button
+            title="현재 위치"
+            onPress={() => Alert.alert('현재위치 표시하는 버튼')}
+          />
+        </View>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
### 이슈넘버 : 1
### 변경내용
* 즐겨찾기, 주변 모달 창 구조를 수정하였습니다.
* 인원 수, 주점 종류, 주종, 선호 지역까지 총 4개 필터를 새로 작성하였습니다. 다만, 아직 서버와 통신 로직을 작성하지는 않았고 틀만 작성해둔 상황입니다.
* 필터링 항목을 작성하며 라이브러리를 추가하였습니다.
> npm i react-native-bouncy-checkbox
(https://www.npmjs.com/package/react-native-bouncy-checkbox?activeTab=dependents)

### 변경로직
* 기존 : tabNavigator -> stackNavigator -> View(모달)
* 변경 : tabNavigator -> Modal(View 대신 Modal 컴포넌트 사용)

### 스크린샷
<img src = https://github.com/hanium-where2go/where2go-Frontend/assets/86345507/5296b1f5-8025-42c2-b3e3-8150fe6e09cf width="300" height="580" />
<img src = https://github.com/hanium-where2go/where2go-Frontend/assets/86345507/01924ad4-6878-4474-be03-2aae0699f2a7 width="300" height="580" />